### PR TITLE
chore: Fix dropdown chip layout shifting issue

### DIFF
--- a/src/components/chip/chip.classnames.ts
+++ b/src/components/chip/chip.classnames.ts
@@ -61,7 +61,7 @@ export const chipSelectionClassnames =
   'data-[state=selected]:bg-solid-slate-1200 data-[state=selected]:fill-solid-slate-50 data-[state=selected]:text-solid-slate-50'
 
 export const chipDropdownClassnames =
-  'm-200 max-w-md border-75 border-solid-slate-75 bg-solid-slate-50 p-200 shadow-530'
+  'absolute min-w-[350px] m-200 max-w-md border-75 border-solid-slate-75 bg-solid-slate-50 p-200 shadow-530'
 
 export const chipDropdownMultiClassnames =
   'px-600 py-[3px] text-75 flex cursor-pointer items-center gap-x-400 rounded-600 p-600 hover:bg-opacity-black-100 hover:text-opacity-black-600'


### PR DESCRIPTION
Describe the bug
When a user opens the dropdown, it is causing an unexpected layout problem. Instead of displaying the dropdown over other elements in the user interface, it is taking up space in the layout and pushing the other elements away. This behavior is not the intended or desired behavior.

Expected behavior
The expected behavior of a dropdown is that it should appear as an overlay over the existing content on the page, without affecting the layout or position of other elements. In other words, when the dropdown is opened, it should display on top of the existing content without causing any disruption to the layout.

The issue is resolved by changing the style of the dropdown panel by making the position absolute. Also added a minimum width of 350px to the panel so it doesn't look small for small-length items.

- Resolves #57