### PR TITLE
Beta - update quill icons package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.0.31-beta.1](https://github.com/deriv-com/quill-design/compare/v1.0.30...v1.0.31-beta.1) (2023-11-10)
+
+
+### ♻️ 	 Chores
+
+* added beta to release workflow [skip ci] ([814f9f3](https://github.com/deriv-com/quill-design/commit/814f9f3570e43d7f2ab65b67a8f4bc9dbd0c045f))
+* updated to latest quill-icons with main exports ([d9a0cb7](https://github.com/deriv-com/quill-design/commit/d9a0cb7787e3f3d402384ba38796e6cd39e9a8f1))
+
 ## [1.0.30](https://github.com/deriv-com/quill-design/compare/v1.0.29...v1.0.30) (2023-11-09)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.0.31-beta.2](https://github.com/deriv-com/quill-design/compare/v1.0.31-beta.1...v1.0.31-beta.2) (2023-11-10)
+
+
+### ♻️ 	 Chores
+
+* updated quill-icons to 1.0.9 ([7fc021b](https://github.com/deriv-com/quill-design/commit/7fc021bdfa7ce48561015aeb89f8b25bd7e15b8a))
+
 ## [1.0.31-beta.1](https://github.com/deriv-com/quill-design/compare/v1.0.30...v1.0.31-beta.1) (2023-11-10)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "typescript": "^5.2.2"
       },
       "peerDependencies": {
-        "@deriv/quill-icons": "^1.0.8",
+        "@deriv/quill-icons": "^1.0.9-beta.1",
         "@headlessui/react": "^1.7.17",
         "@types/react": "^17.x || ^18.x",
         "class-variance-authority": "^0.7.0",
@@ -2679,9 +2679,9 @@
       }
     },
     "node_modules/@deriv/quill-icons": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-1.0.8.tgz",
-      "integrity": "sha512-2Olf6nRaGXfgWYlgLIo+AM7M3FscT99Vfi5FSpl872uyTa+yyKXZhpQ6Lus2BkzTABsaT3907w1/g8IOCCsFew==",
+      "version": "1.0.9-beta.1",
+      "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-1.0.9-beta.1.tgz",
+      "integrity": "sha512-YzJX5TjaV015TsqodoHfYg6R6gzxQJhM6ecrKkm94Nms0uP704QTtZDTyZG25+qTae8nAiocsC1CRQ2ig1eK1A==",
       "peer": true,
       "peerDependencies": {
         "react": ">= 16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "typescript": "^5.2.2"
       },
       "peerDependencies": {
-        "@deriv/quill-icons": "^1.0.9-beta.1",
+        "@deriv/quill-icons": "^1.0.9",
         "@headlessui/react": "^1.7.17",
         "@types/react": "^17.x || ^18.x",
         "class-variance-authority": "^0.7.0",
@@ -2679,9 +2679,9 @@
       }
     },
     "node_modules/@deriv/quill-icons": {
-      "version": "1.0.9-beta.1",
-      "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-1.0.9-beta.1.tgz",
-      "integrity": "sha512-YzJX5TjaV015TsqodoHfYg6R6gzxQJhM6ecrKkm94Nms0uP704QTtZDTyZG25+qTae8nAiocsC1CRQ2ig1eK1A==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-1.0.9.tgz",
+      "integrity": "sha512-BqC5/u1kwVSscRmboiKNHadeNmNaMT6etBqeLADJ9881vlmirzLhEhY5igSrPUaflyyEPpUNTamDBMUm9DKxww==",
       "peer": true,
       "peerDependencies": {
         "react": ">= 16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@deriv/quill-design",
-  "version": "1.0.30",
+  "version": "1.0.31-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@deriv/quill-design",
-      "version": "1.0.30",
+      "version": "1.0.31-beta.1",
       "license": "ISC",
       "devDependencies": {
         "@babel/preset-env": "^7.22.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@deriv/quill-design",
-  "version": "1.0.31-beta.1",
+  "version": "1.0.31-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@deriv/quill-design",
-      "version": "1.0.31-beta.1",
+      "version": "1.0.31-beta.2",
       "license": "ISC",
       "devDependencies": {
         "@babel/preset-env": "^7.22.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deriv/quill-design",
-  "version": "1.0.31-beta.1",
+  "version": "1.0.31-beta.2",
   "description": "Deriv Quill Design UI library",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "@deriv/quill-icons": "^1.0.8",
+    "@deriv/quill-icons": "^1.0.9-beta.1",
     "@headlessui/react": "^1.7.17",
     "@types/react": "^17.x || ^18.x",
     "class-variance-authority": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "@deriv/quill-icons": "^1.0.9-beta.1",
+    "@deriv/quill-icons": "^1.0.9",
     "@headlessui/react": "^1.7.17",
     "@types/react": "^17.x || ^18.x",
     "class-variance-authority": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deriv/quill-design",
-  "version": "1.0.30",
+  "version": "1.0.31-beta.1",
   "description": "Deriv Quill Design UI library",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/components/chip/types.tsx
+++ b/src/components/chip/types.tsx
@@ -1,4 +1,4 @@
-import { QuillSvgProps } from '@deriv/quill-icons/QuillTypes'
+import { QuillSvgProps } from '@deriv/quill-icons'
 import { chipBaseVariant } from './chip.classnames'
 import { type VariantProps } from 'class-variance-authority'
 import { ExcludeNull } from 'types'

--- a/src/components/input/base/index.tsx
+++ b/src/components/input/base/index.tsx
@@ -1,4 +1,4 @@
-import { QuillSvgProps } from '@deriv/quill-icons/QuillTypes'
+import { QuillSvgProps } from '@deriv/quill-icons'
 import {
   ForwardRefExoticComponent,
   HTMLAttributes,

--- a/src/components/tag/index.tsx
+++ b/src/components/tag/index.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef, HTMLAttributes } from 'react'
 import { TagClassNamesCVA, TagProps, TagSizeCVA } from './tag.classnames'
 import qtMerge from 'qtMerge'
 import TagIcon from './tag.icon'
-import { QuillSvgProps } from '@deriv/quill-icons/QuillTypes'
+import { QuillSvgProps } from '@deriv/quill-icons'
 
 export interface TagComponentProps
   extends HTMLAttributes<HTMLDivElement>,

--- a/src/components/tag/tag.classnames.ts
+++ b/src/components/tag/tag.classnames.ts
@@ -10,7 +10,7 @@ import {
   LabelPairedCircleInfoRegularIcon,
 } from '@deriv/quill-icons/LabelPaired'
 import { ExcludeNull } from 'types'
-import { QuillSvgProps } from '@deriv/quill-icons/QuillTypes'
+import { QuillSvgProps } from '@deriv/quill-icons'
 
 export type BaseTagProps = ExcludeNull<
   VariantProps<typeof TagClassNamesCVA>,

--- a/src/components/tag/tag.icon.tsx
+++ b/src/components/tag/tag.icon.tsx
@@ -1,4 +1,4 @@
-import { QuillSvgProps } from '@deriv/quill-icons/QuillTypes'
+import { QuillSvgProps } from '@deriv/quill-icons'
 import {
   BaseTagIconProps,
   BaseTagProps,


### PR DESCRIPTION
- chore: updated to latest quill-icons with main exports
- ci: release(version): Release 1.0.31-beta.1 [skip ci]
- chore: updated quill-icons to 1.0.9
