### PR TITLE
chore: updated fluid container paddings on mobile, tablet

### DIFF
--- a/__snapshots__/components/containers/containers.test.tsx.snap
+++ b/__snapshots__/components/containers/containers.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`FixContainer should render correctly 1`] = `
 exports[`FluidContainer should render correctly 1`] = `
 <div>
   <div
-    class="mx-auto w-full max-w-[1232px] px-general-md 2xl:px-general-none"
+    class="mx-auto w-full max-w-[1232px] px-800 md:px-1200 lg:px-general-none"
   />
 </div>
 `;

--- a/src/components/containers/fluid/index.tsx
+++ b/src/components/containers/fluid/index.tsx
@@ -8,7 +8,7 @@ export const FluidContainer = ({
   return (
     <div
       className={qtMerge(
-        'mx-auto w-full max-w-[1232px] px-general-md 2xl:px-general-none',
+        'mx-auto w-full max-w-[1232px] px-800 md:px-1200 lg:px-general-none',
         className,
       )}
       {...rest}


### PR DESCRIPTION
- on mobile we have 16px paddings
- on tablet we have 24px paddings
- on laptop we have no paddings