### PR TITLE
chore: Improve chip component controlled selection behaviour

### DIFF
--- a/__snapshots__/components/chip/selectable-chip/selectable-chip.test.tsx.snap
+++ b/__snapshots__/components/chip/selectable-chip/selectable-chip.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Selectable Chip should render correctly with lg size 1`] = `
 <button
-  class="max-h-2400 gap-x-400 px-1200 py-[7px] text-100 cursor-pointer inline-flex items-center justify-center rounded-4800 border-75 border-opacity-black-100 font-regular text-typography-default enabled:hover:bg-opacity-black-100 enabled:hover:text-opacity-black-600 disabled:fill-opacity-black-300 disabled:text-opacity-black-300 data-[state=selected]:enabled:border-solid-slate-1200 data-[state=selected]:enabled:bg-solid-slate-1200 data-[state=selected]:enabled:fill-solid-slate-50 data-[state=selected]:enabled:text-solid-slate-50 group"
+  class="max-h-2400 w-max min-w-[96px] gap-x-400 px-1200 py-[7px] text-100 cursor-pointer inline-flex items-center justify-center rounded-4800 border-75 border-opacity-black-100 font-regular text-typography-default enabled:hover:bg-opacity-black-100 enabled:hover:text-opacity-black-600 disabled:fill-opacity-black-300 disabled:text-opacity-black-300 data-[state=selected]:enabled:border-solid-slate-1200 data-[state=selected]:enabled:bg-solid-slate-1200 data-[state=selected]:enabled:fill-solid-slate-50 data-[state=selected]:enabled:text-solid-slate-50 group"
   data-state=""
 >
   <div
@@ -15,7 +15,7 @@ exports[`Selectable Chip should render correctly with lg size 1`] = `
 
 exports[`Selectable Chip should render correctly with md size 1`] = `
 <button
-  class="max-h-1600 gap-x-400 px-800 py-[5px] text-75 cursor-pointer inline-flex items-center justify-center rounded-4800 border-75 border-opacity-black-100 font-regular text-typography-default enabled:hover:bg-opacity-black-100 enabled:hover:text-opacity-black-600 disabled:fill-opacity-black-300 disabled:text-opacity-black-300 data-[state=selected]:enabled:border-solid-slate-1200 data-[state=selected]:enabled:bg-solid-slate-1200 data-[state=selected]:enabled:fill-solid-slate-50 data-[state=selected]:enabled:text-solid-slate-50 group"
+  class="max-h-1600 w-max min-w-[72px] gap-x-400 px-800 py-[5px] text-75 cursor-pointer inline-flex items-center justify-center rounded-4800 border-75 border-opacity-black-100 font-regular text-typography-default enabled:hover:bg-opacity-black-100 enabled:hover:text-opacity-black-600 disabled:fill-opacity-black-300 disabled:text-opacity-black-300 data-[state=selected]:enabled:border-solid-slate-1200 data-[state=selected]:enabled:bg-solid-slate-1200 data-[state=selected]:enabled:fill-solid-slate-50 data-[state=selected]:enabled:text-solid-slate-50 group"
   data-state=""
 >
   <div
@@ -28,7 +28,7 @@ exports[`Selectable Chip should render correctly with md size 1`] = `
 
 exports[`Selectable Chip should render correctly with sm size 1`] = `
 <button
-  class="max-h-1200 gap-x-400 px-600 py-[3px] text-50 cursor-pointer inline-flex items-center justify-center rounded-4800 border-75 border-opacity-black-100 font-regular text-typography-default enabled:hover:bg-opacity-black-100 enabled:hover:text-opacity-black-600 disabled:fill-opacity-black-300 disabled:text-opacity-black-300 data-[state=selected]:enabled:border-solid-slate-1200 data-[state=selected]:enabled:bg-solid-slate-1200 data-[state=selected]:enabled:fill-solid-slate-50 data-[state=selected]:enabled:text-solid-slate-50 group"
+  class="max-h-1200 w-max min-w-[56px] gap-x-400 px-600 py-[3px] text-50 cursor-pointer inline-flex items-center justify-center rounded-4800 border-75 border-opacity-black-100 font-regular text-typography-default enabled:hover:bg-opacity-black-100 enabled:hover:text-opacity-black-600 disabled:fill-opacity-black-300 disabled:text-opacity-black-300 data-[state=selected]:enabled:border-solid-slate-1200 data-[state=selected]:enabled:bg-solid-slate-1200 data-[state=selected]:enabled:fill-solid-slate-50 data-[state=selected]:enabled:text-solid-slate-50 group"
   data-state=""
 >
   <div

--- a/src/components/chip/chip.classnames.ts
+++ b/src/components/chip/chip.classnames.ts
@@ -4,9 +4,33 @@ import { cva } from 'class-variance-authority'
 export const chipBaseVariant = cva('', {
   variants: {
     size: {
-      sm: ['max-h-1200', 'gap-x-400', 'px-600', 'py-[3px]', 'text-50'],
-      md: ['max-h-1600', 'gap-x-400', 'px-800', 'py-[5px]', 'text-75'],
-      lg: ['max-h-2400', 'gap-x-400', 'px-1200', 'py-[7px]', 'text-100'],
+      sm: [
+        'max-h-1200',
+        'w-max',
+        'min-w-[56px]',
+        'gap-x-400',
+        'px-600',
+        'py-[3px]',
+        'text-50',
+      ],
+      md: [
+        'max-h-1600',
+        'w-max',
+        'min-w-[72px]',
+        'gap-x-400',
+        'px-800',
+        'py-[5px]',
+        'text-75',
+      ],
+      lg: [
+        'max-h-2400',
+        'w-max',
+        'min-w-[96px]',
+        'gap-x-400',
+        'px-1200',
+        'py-[7px]',
+        'text-100',
+      ],
     },
     dismissible: {
       true: ['cursor-default'],

--- a/src/components/chip/selectable-chip/index.tsx
+++ b/src/components/chip/selectable-chip/index.tsx
@@ -24,7 +24,7 @@ export const SelectableChip = forwardRef<
       icon: Icon,
       isDropdownOpen,
       dropdown = false,
-      selected = false,
+      selected,
       labelTag,
       onChipSelect,
       onDismiss,
@@ -35,11 +35,15 @@ export const SelectableChip = forwardRef<
   ) => {
     const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
       if (dismissible || dropdown) return
-      const target = event.currentTarget
-      const isSelected = target.getAttribute('data-state') === 'selected'
-      const selected_state = isSelected ? '' : 'selected'
-      target.setAttribute('data-state', selected_state)
-      onChipSelect?.(event, !isSelected)
+      if (selected === undefined) {
+        const target = event.currentTarget
+        const isSelected = target.getAttribute('data-state') === 'selected'
+        const selected_state = isSelected ? '' : 'selected'
+        target.setAttribute('data-state', selected_state)
+        onChipSelect?.(event, !isSelected)
+      } else {
+        onChipSelect?.(event, selected)
+      }
     }
 
     const handleDismiss = (

--- a/src/components/chip/selectable-chip/selectable-chip.stories.ts
+++ b/src/components/chip/selectable-chip/selectable-chip.stories.ts
@@ -40,7 +40,12 @@ const meta = {
         type: 'select',
       },
     },
-    onChipSelect: { action: 'onChipSelect' },
+    selected: {
+      name: 'selected',
+      control: 'boolean',
+      description:
+        'A boolean flag indicating whether the chip is in a selected/active state. If `selected` is set to `true` or `false`, the chip will act as a controlled component, allowing external control over its state. If no value is passed (undefined), the chip will be uncontrolled, and its state will be managed internally.',
+    },
   },
   tags: ['autodocs'],
 } satisfies Meta<typeof Chip>


### PR DESCRIPTION
Improved Chip component control behavior

- Added condition to trigger the selection behavior only if no `selected` value or `undefined` is passed
- Updated the style for the base component to accommodate max content width
- Updated test case snapshots
- Added detailed description for selected prop in storybook
- Resolves #100 